### PR TITLE
【検索】UsecaseをGenericsに書き換え

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/DomainModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/DomainModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
 import jp.co.yumemi.android.code_check.domain.core.ErrorHandler
+import jp.co.yumemi.android.code_check.domain.entities.Repository
 import jp.co.yumemi.android.code_check.domain.repositories.RepositoriesRepository
 import jp.co.yumemi.android.code_check.domain.repositories.SearchRepository
 import jp.co.yumemi.android.code_check.domain.usecases.ClearRecentSearchesExecutor
@@ -13,17 +14,17 @@ import jp.co.yumemi.android.code_check.domain.usecases.GetRecentSearchesExecutor
 import jp.co.yumemi.android.code_check.domain.usecases.GetRecentSearchesUseCase
 import jp.co.yumemi.android.code_check.domain.usecases.GetRepositoryDetailsExecutor
 import jp.co.yumemi.android.code_check.domain.usecases.GetRepositoryDetailsUseCase
-import jp.co.yumemi.android.code_check.domain.usecases.SearchRepoExecutor
+import jp.co.yumemi.android.code_check.domain.usecases.SearchRepositoryExecutor
 import jp.co.yumemi.android.code_check.domain.usecases.SearchRepoUseCase
 
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 class DomainModule {
     @Provides
-    fun provideSearchRepoUseCase(
+    fun provideSearchRepositoryUseCase(
         searchRepository: SearchRepository,
         errorHandler: ErrorHandler
-    ): SearchRepoUseCase = SearchRepoExecutor(searchRepository, errorHandler)
+    ): SearchRepoUseCase<Repository> = SearchRepositoryExecutor(searchRepository, errorHandler)
 
     @Provides
     fun provideClearRecentSearchesUseCase(

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/SearchUseCase.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/SearchUseCase.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.domain.usecases
 
+import android.os.Parcelable
 import jp.co.yumemi.android.code_check.domain.core.DomainResult
 import jp.co.yumemi.android.code_check.domain.core.ErrorHandler
 import jp.co.yumemi.android.code_check.domain.core.Pageable
@@ -8,14 +9,14 @@ import jp.co.yumemi.android.code_check.domain.core.toDomainResult
 import jp.co.yumemi.android.code_check.domain.entities.Repository
 import jp.co.yumemi.android.code_check.domain.repositories.SearchRepository
 
-interface SearchRepoUseCase : UseCase<SearchRepoUseCase.Args, DomainResult<Pageable<Repository>>> {
+interface SearchRepoUseCase<T : Parcelable> : UseCase<SearchRepoUseCase.Args, DomainResult<Pageable<T>>> {
     data class Args(val searchText: String, val pageNumber: Int)
 }
 
-class SearchRepoExecutor(
+class SearchRepositoryExecutor(
     private val searchRepository: SearchRepository,
     private val errorHandler: ErrorHandler
-) : SearchRepoUseCase {
+) : SearchRepoUseCase<Repository> {
     override suspend fun execute(
         arguments: SearchRepoUseCase.Args
     ): DomainResult<Pageable<Repository>> = runCatching {

--- a/domain/src/test/kotlin/jp/co/yumemi/android/code_check/domain/usecases/SearchRepoExecutorTest.kt
+++ b/domain/src/test/kotlin/jp/co/yumemi/android/code_check/domain/usecases/SearchRepoExecutorTest.kt
@@ -20,13 +20,13 @@ import org.junit.Rule
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
-class SearchRepoExecutorTest {
+class SearchRepositoryExecutorTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
     private val searchRepository = mockk<SearchRepository>()
     private val errorHandler = mockk<ErrorHandler>()
     private val testException = Exception("test")
-    private val searchRepoUseCase = SearchRepoExecutor(searchRepository, errorHandler)
+    private val searchRepoUseCase = SearchRepositoryExecutor(searchRepository, errorHandler)
 
     @Test
     fun `test when execute is successful`() {

--- a/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/search/results/SearchRepositoryResultsProcessor.kt
+++ b/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/search/results/SearchRepositoryResultsProcessor.kt
@@ -22,7 +22,7 @@ class SearchRepositoryResultsProcessor(
         SearchResultsViewState<Repository>,
         SearchResultsEvent<Repository>,
         SearchResultsSideEffect<Repository>>,
-    private val searchRepoUseCase: SearchRepoUseCase
+    private val searchRepoUseCase: SearchRepoUseCase<Repository>
 ) : SearchResultsProcessor<Repository>(stateMachine) {
     override suspend fun process(
         sideEffect: SearchResultsSideEffect<Repository>,

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/search/results/repository/SearchRepositoryResultsModule.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/search/results/repository/SearchRepositoryResultsModule.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.FlowPreview
 @ExperimentalCoroutinesApi
 @Module
 @InstallIn(ActivityRetainedComponent::class)
-class SearchResultsModule {
+class SearchRepositoryResultsModule {
     @Provides
     fun provideSearchRepositoryResultsStateMachine(): SearchResultsStateMachine<Repository> = SearchResultsStateMachine()
 
@@ -40,6 +40,6 @@ class SearchResultsModule {
     @Provides
     fun provideSearchRepositoryResultsProcessor(
         stateMachine: SearchResultsStateMachine<Repository>,
-        searchRepoUseCase: SearchRepoUseCase
+        searchRepoUseCase: SearchRepoUseCase<Repository>
     ): SearchResultsProcessor<Repository> = SearchRepositoryResultsProcessor(stateMachine, searchRepoUseCase)
 }


### PR DESCRIPTION
# 概要
・UsecaseでGenerics使うと、他の機能の実装がしやすくなる

# 変更種類
- [ ] フィーチャー実装
- [ ] バッグ修正
- [x] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [x] Unit Test
- [ ] UI Test
- [ ] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
