### PR TITLE
【バグ修正】RepoNameを取り出す

### DIFF
--- a/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/mappers/IssueDataMapper.kt
+++ b/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/mappers/IssueDataMapper.kt
@@ -9,7 +9,7 @@ object IssueDataMapper {
         number = model.number,
         title = model.title,
         createdAt = model.createdAt,
-        repository = model.repository?.let(RepositoryDataMapper::toEntity),
+        repoName = model.repoName,
         status = model.state
     )
 }

--- a/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/mappers/PullRequestDataMapper.kt
+++ b/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/mappers/PullRequestDataMapper.kt
@@ -10,7 +10,7 @@ object PullRequestDataMapper {
             title = model.title,
             user = model.user?.let(UserDataMapper::toEntity),
             number = model.number,
-            repository = model.repository?.let(RepositoryDataMapper::toEntity),
+            repoName = model.repoName,
             createdAt = model.date,
             status = model.status
         )

--- a/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/models/IssueModel.kt
+++ b/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/models/IssueModel.kt
@@ -1,12 +1,10 @@
 package jp.co.yumemi.android.code_check.data.models
 
-import jp.co.yumemi.android.code_check.domain.entities.Repository
-
 data class IssueModel(
     val id: Int,
     val number: Int,
     val title: String,
     val createdAt: String,
-    val repository: RepositoryModel?,
+    val repoName: String,
     val state: String,
 )

--- a/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/models/PullRequestModel.kt
+++ b/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/models/PullRequestModel.kt
@@ -5,7 +5,7 @@ data class PullRequestModel(
     val title: String,
     val user: UserModel?,
     val number: Int,
-    val repository: RepositoryModel?,
+    val repoName: String,
     val date: String,
     val status: String,
 )

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/Issue.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/Issue.kt
@@ -9,6 +9,6 @@ data class Issue(
     val number: Int,
     val title: String,
     val createdAt: String,
-    val repository: Repository?,
+    val repoName: String,
     val status: String,
 ) : Parcelable

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/PullRequest.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/PullRequest.kt
@@ -9,7 +9,7 @@ data class PullRequest(
     val title: String,
     val number: Int,
     val user: User?,
-    val repository: Repository?,
+    val repoName: String,
     val createdAt: String,
     val status: String
 ) : Parcelable

--- a/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/core/HttpClientConfigExt.kt
+++ b/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/core/HttpClientConfigExt.kt
@@ -1,11 +1,11 @@
 package jp.co.yumemi.android.code_check.remote.core
 
+import android.util.Log
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.DEFAULT
 import io.ktor.client.features.logging.LogLevel
 import io.ktor.client.features.logging.Logger
 import io.ktor.client.features.logging.Logging
@@ -44,6 +44,10 @@ fun HttpClientConfig<*>.installDefaultRequest() = defaultRequest {
 fun HttpClientConfig<*>.installLogging() {
     install(Logging) {
         level = LogLevel.ALL
-        logger = Logger.DEFAULT
+        logger = object : Logger {
+            override fun log(message: String) {
+                Log.d("Ktor", message)
+            }
+        }
     }
 }

--- a/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/mappers/IssueRemoteMapper.kt
+++ b/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/mappers/IssueRemoteMapper.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.code_check.remote.mappers
 
 import jp.co.yumemi.android.code_check.data.models.IssueModel
 import jp.co.yumemi.android.code_check.remote.models.IssueMinusSearchMinusResultMinusItemApiModel
+import jp.co.yumemi.android.code_check.remote.utils.filterRepoName
 
 object IssueRemoteMapper {
     fun toModel(apiModel: IssueMinusSearchMinusResultMinusItemApiModel) = IssueModel(
@@ -9,7 +10,7 @@ object IssueRemoteMapper {
         number = apiModel.number,
         title = apiModel.title,
         createdAt = apiModel.createdAt,
-        repository = apiModel.repository?.let(RepositoryRemoteMapper::toModel),
+        repoName = apiModel.url.filterRepoName(endPathDelimiter = "issues"),
         state = apiModel.state
     )
 }

--- a/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/mappers/PullRequestRemoteMapper.kt
+++ b/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/mappers/PullRequestRemoteMapper.kt
@@ -3,6 +3,7 @@ package jp.co.yumemi.android.code_check.remote.mappers
 import jp.co.yumemi.android.code_check.data.models.PullRequestModel
 import jp.co.yumemi.android.code_check.remote.models.IssueMinusSearchMinusResultMinusItemApiModel
 import jp.co.yumemi.android.code_check.remote.models.PullMinusRequestMinusSimpleApiModel
+import jp.co.yumemi.android.code_check.remote.utils.filterRepoName
 
 object PullRequestRemoteMapper {
     fun toModel(apiModel: PullMinusRequestMinusSimpleApiModel) =
@@ -11,7 +12,7 @@ object PullRequestRemoteMapper {
             title = apiModel.title,
             user = apiModel.user?.let(UserRemoteMapper::toModel),
             number = apiModel.number,
-            repository = null,
+            repoName = apiModel.url.filterRepoName(endPathDelimiter = "issues"),
             date = apiModel.createdAt,
             status = apiModel.state
         )
@@ -22,7 +23,7 @@ object PullRequestRemoteMapper {
             title = apiModel.title,
             number = apiModel.number,
             user = apiModel.user?.let(UserRemoteMapper::toModel),
-            repository = apiModel.repository?.let(RepositoryRemoteMapper::toModel),
+            repoName = apiModel.url.filterRepoName(endPathDelimiter = "issues"),
             date = apiModel.createdAt,
             status = apiModel.state
         )

--- a/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/utils/StringExt.kt
+++ b/remote/src/main/kotlin/jp/co/yumemi/android/code_check/remote/utils/StringExt.kt
@@ -1,0 +1,4 @@
+package jp.co.yumemi.android.code_check.remote.utils
+
+fun String.filterRepoName(startPathDelimiter: String = "repos", endPathDelimiter: String) =
+    substringAfter("https://api.github.com/$startPathDelimiter/").substringBefore("/$endPathDelimiter")

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/components/search/SearchIssueResultItem.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/components/search/SearchIssueResultItem.kt
@@ -80,13 +80,12 @@ fun SearchIssueResultItem(
 fun SearchIssueResultItem(
     issue: Issue,
     modifier: Modifier = Modifier,
-    repoName: String = issue.repository?.name ?: "",
 ) {
     val status = IssueStatus(issue.status)
     SearchIssueResultItem(
         icon = status.icon,
         iconTint = status.iconTint,
-        repoName = repoName,
+        repoName = issue.repoName,
         number = issue.number.toString(),
         title = issue.title,
         daysAgo = issue.createdAt,
@@ -98,13 +97,12 @@ fun SearchIssueResultItem(
 fun SearchPullRequestResultItem(
     pullRequest: PullRequest,
     modifier: Modifier = Modifier,
-    repoName: String = pullRequest.repository?.name ?: "",
 ) {
     val status = PullRequestStatus(pullRequest.status)
     SearchIssueResultItem(
         icon = status.icon,
         iconTint = status.iconTint,
-        repoName = repoName,
+        repoName = pullRequest.repoName,
         number = pullRequest.number.toString(),
         title = pullRequest.title,
         daysAgo = pullRequest.createdAt,


### PR DESCRIPTION
# 概要
・サーチAPIからrepositoryがnullになるので、urlから取り出すことにした

# 変更種類
- [ ] フィーチャー実装
- [ ] バッグ修正
- [ ] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [ ] Unit Test
- [ ] UI Test
- [ ] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
