### PR TITLE
【リファクタ】derivedStateOfを使う

### DIFF
--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/details/repo/RepoDetailsScreen.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/details/repo/RepoDetailsScreen.kt
@@ -53,7 +53,7 @@ fun RepoDetailsScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         TitleAppBar(
             title = stringResource(id = R.string.common_repositories),
-            elevation = scrollState.elevation,
+            elevation = scrollState.elevation(),
             navigationIcon = {
                 BackIcon { dispatch(RepoDetailsIntent.ClickBack) }
             }

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/search/results/SearchResultsScreen.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/features/search/results/SearchResultsScreen.kt
@@ -57,7 +57,7 @@ fun <T : Parcelable> SearchResultsScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         TitleAppBar(
             title = stringResource(id = title),
-            elevation = scrollState.elevation,
+            elevation = scrollState.elevation(),
             navigationIcon = {
                 BackIcon { dispatch(SearchResultsIntent.ClickBack()) }
             }

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/DateString.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/DateString.kt
@@ -1,6 +1,8 @@
 package jp.co.yumemi.android.code_check.ui.utils
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import jp.co.yumemi.android.code_check.ui.R
 import kotlinx.datetime.Clock
@@ -9,22 +11,26 @@ import kotlinx.datetime.Instant
 data class DateString(val value: String) {
     @Composable
     fun toDurationUntilToday(): String {
-        val date = Instant.parse(value)
-        val now = Clock.System.now()
-        val duration = (now - date).absoluteValue
+        val result = remember {
+            derivedStateOf {
+                val date = Instant.parse(value)
+                val now = Clock.System.now()
+                (now - date).absoluteValue
+            }
+        }
         return when {
-            duration.inWholeMinutes < nowMinutes -> stringResource(id = R.string.common_time_now)
-            duration.inWholeMinutes < minutesInHour -> "${duration.inWholeMinutes}${stringResource(id = R.string.common_time_minutes)}"
-            duration.inWholeHours < hoursInDay -> "${duration.inWholeHours}${stringResource(id = R.string.common_time_hours)}"
-            duration.inWholeDays < daysInWeek -> "${duration.inWholeDays}${stringResource(id = R.string.common_time_days)}"
-            duration.inWholeDays < daysInMonth -> "${duration.inWholeDays / daysInWeek}${stringResource(id = R.string.common_time_weeks)}"
-            duration.inWholeDays < daysInYear -> "${duration.inWholeDays / daysInMonth}${stringResource(id = R.string.common_time_months)}"
-            else -> "${duration.inWholeDays / daysInYear}${stringResource(id = R.string.common_time_minutes)}"
+            result.value.inWholeMinutes < nowMinutes -> stringResource(id = R.string.common_time_now)
+            result.value.inWholeMinutes < minutesInHour -> "${result.value.inWholeMinutes}${stringResource(id = R.string.common_time_minutes)}"
+            result.value.inWholeHours < hoursInDay -> "${result.value.inWholeHours}${stringResource(id = R.string.common_time_hours)}"
+            result.value.inWholeDays < daysInWeek -> "${result.value.inWholeDays}${stringResource(id = R.string.common_time_days)}"
+            result.value.inWholeDays < daysInMonth -> "${result.value.inWholeDays / daysInWeek}${stringResource(id = R.string.common_time_weeks)}"
+            result.value.inWholeDays < daysInYear -> "${result.value.inWholeDays / daysInMonth}${stringResource(id = R.string.common_time_months)}"
+            else -> "${result.value.inWholeDays / daysInYear}${stringResource(id = R.string.common_time_minutes)}"
         }
     }
 
     companion object {
-        private const val nowMinutes = 2
+        private const val nowMinutes = 2L
         private const val minutesInHour = 60
         private const val hoursInDay = 24
         private const val daysInWeek = 7

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/LazyListStateExt.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/LazyListStateExt.kt
@@ -13,19 +13,39 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 // ref: https://manavtamboli.medium.com/infinite-list-paged-list-in-jetpack-compose-b10fc7e74768
-val LazyListState.firstVisibleItem get() = layoutInfo.visibleItemsInfo.firstOrNull()
-val LazyListState.lastVisibleItem get() = layoutInfo.visibleItemsInfo.lastOrNull()
-val LazyListState.isAtTop: Boolean
-    get() {
-        val firstVisibleItem = firstVisibleItem ?: return true
-        return firstVisibleItem.index == 0 && firstVisibleItem.offset == 0
+@Composable
+fun LazyListState.isAtTop(): Boolean {
+    val isAtTop = remember {
+        derivedStateOf {
+            val firstVisibleItem = firstVisibleItem ?: return@derivedStateOf true
+            firstVisibleItem.index == 0 && firstVisibleItem.offset == 0
+        }
     }
-val LazyListState.isAtBottom: Boolean
-    get() {
-        val lastVisibleItem = lastVisibleItem ?: return true
-        return lastVisibleItem.index == layoutInfo.totalItemsCount - 1 && lastVisibleItem.offset == layoutInfo.viewportSize.height - lastVisibleItem.size
+    return isAtTop.value
+}
+
+@Composable
+fun LazyListState.isAtBottom(): Boolean {
+    val isAtBottom = remember {
+        derivedStateOf {
+            val lastVisibleItem = lastVisibleItem ?: return@derivedStateOf true
+            lastVisibleItem.index == layoutInfo.totalItemsCount - 1 && lastVisibleItem.offset == layoutInfo.viewportSize.height - lastVisibleItem.size
+        }
     }
-val LazyListState.elevation: Dp get() = if (isAtTop) 0.dp else 4.dp // TODO: Issues when setting background colors
+    return isAtBottom.value
+}
+
+@Composable
+fun LazyListState.elevation(): Dp {
+    val elevation = remember {
+        derivedStateOf {
+            val firstVisibleItem = firstVisibleItem ?: return@derivedStateOf 0.dp
+            val isAtTop = firstVisibleItem.index == 0 && firstVisibleItem.offset == 0
+            if (isAtTop) 0.dp else 4.dp
+        }
+    }
+    return elevation.value
+}
 
 @SuppressLint("ComposableNaming")
 @Composable
@@ -68,3 +88,6 @@ fun LazyListState.onScrolledToBottom(
             .collect { if (it) onNotify() }
     }
 }
+
+private val LazyListState.firstVisibleItem get() = layoutInfo.visibleItemsInfo.firstOrNull()
+private val LazyListState.lastVisibleItem get() = layoutInfo.visibleItemsInfo.lastOrNull()

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/ScrollStateExt.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/ScrollStateExt.kt
@@ -1,7 +1,28 @@
 package jp.co.yumemi.android.code_check.ui.utils
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-val ScrollState.isAtTop get() = this.value == 0
-val ScrollState.elevation get() = if (isAtTop) 0.dp else 4.dp
+@Composable
+fun ScrollState.isAtTop(): Boolean {
+    val isAtTop = remember {
+        derivedStateOf {
+            this.value == 0
+        }
+    }
+    return isAtTop.value
+}
+
+@Composable
+fun ScrollState.elevation(): Dp {
+    val elevation = remember {
+        derivedStateOf {
+            if (value == 0) 0.dp else 4.dp
+        }
+    }
+    return elevation.value
+}


### PR DESCRIPTION
# 概要
・Extの中にderivedStateOfを使うようにした。それを使わないと毎回recomposeされる時に計算されるので、パフォーマンスが落ちる

# 変更種類
- [ ] フィーチャー実装
- [ ] バッグ修正
- [x] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [ ] Unit Test
- [ ] UI Test
- [ ] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
