### PR TITLE
【リファクタ】buildSrcとbuild.gradle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ jobs:
       - gradle:
           title: unit test
           task: testDevDebugUnitTest
-#      - gradle:
-#          title: code coverage
-#          task: koverMergedXmlReport
-#      - danger:
-#          path: ./Dangerfile-Test
+      - gradle:
+          title: code coverage
+          task: koverMergedXmlReport
+      - danger:
+          path: ./Dangerfile-Test
       - store_test_results:
           path: build/reports/kover/
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id(Dependencies.Plugin.ktlint) version Versions.ktLint
-    id(Dependencies.Plugin.kover) version Versions.kover
     id(Dependencies.Plugin.dokka) version Versions.dokka
+    id(Dependencies.Plugin.kover)
+    id(Dependencies.Plugin.ktlint)
 }
 
 buildscript {
@@ -20,47 +20,7 @@ buildscript {
     }
 }
 
-allprojects {
-    plugins.apply(Dependencies.Plugin.dokka)
-    plugins.apply(Dependencies.Plugin.ktlint)
-
-    ktlint {
-        verbose.set(true)
-        android.set(true)
-        ignoreFailures.set(true)
-        coloredOutput.set(true)
-        outputColorName.set("RED")
-        additionalEditorconfigFile.set(File("${rootDir.path}/.editorconfig"))
-        reporters {
-            reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
-            reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
-        }
-        filter {
-            include("**/kotlin/**")
-            include("*.kts")
-            exclude("**/generated/**")
-            exclude("**/remote/models/**")
-            exclude("**/remote/apis/**")
-        }
-    }
-}
-
-tasks.withType(kotlinx.kover.tasks.KoverMergedTask::class) {
-    excludes = listOf(
-        "*.BuildConfig",
-        "*.databinding.*",
-        "*.test.*",
-        "*.domain.core.*",
-        "*.domain.entity.*",
-        "*.data.models.*",
-        "*.remote.core.*",
-        "*.remote.models.*",
-        "*.remote.apis.*",
-        "*.local.core.*",
-        "*.local.models.*",
-        "*.local.dao.*"
-    )
-}
+setupTestCoverageTask()
 
 tasks.register("clean", Delete::class) {
     group = "cleanup"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,25 +1,4 @@
-buildscript {
-    val kotlinVersion = "1.6.10"
-
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
-    dependencies {
-        classpath(kotlin("gradle-plugin", kotlinVersion))
-    }
-
-    configurations.classpath.get().resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.kotlin") {
-            useVersion(kotlinVersion)
-        }
-    }
-}
-
 plugins {
-    `java-gradle-plugin`
     `kotlin-dsl`
 }
 
@@ -30,9 +9,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly(gradleApi())
-    implementation(kotlin("gradle-plugin"))
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
     implementation("com.android.tools.build:gradle:7.0.3")
-    implementation(kotlin("script-runtime"))
+    implementation("org.jetbrains.kotlinx:kover:0.5.0")
+    implementation("org.jlleitschuh.gradle:ktlint-gradle:10.2.1")
 }

--- a/buildSrc/src/main/kotlin/SetupAndroid.kt
+++ b/buildSrc/src/main/kotlin/SetupAndroid.kt
@@ -51,6 +51,8 @@ fun Project.setupAndroid() {
 
     setupAndroidApp()
     setupAndroidLibrary()
+    setupLinter()
+    setupTestCoverage()
 }
 
 private fun Project.setupAndroidApp() {

--- a/buildSrc/src/main/kotlin/SetupJetpackCompose.kt
+++ b/buildSrc/src/main/kotlin/SetupJetpackCompose.kt
@@ -1,21 +1,7 @@
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.setupJetpackCompose() {
-    extensions.findByType(BaseAppModuleExtension::class.java)?.apply {
-        buildFeatures {
-            compose = true
-        }
-
-        composeOptions {
-            kotlinCompilerExtensionVersion = Versions.compose
-        }
-    }
-
-    extensions.findByType(LibraryExtension::class.java)?.apply {
+    extensions.findByType(com.android.build.api.dsl.CommonExtension::class.java)?.apply {
         buildFeatures {
             compose = true
         }

--- a/buildSrc/src/main/kotlin/SetupLinter.kt
+++ b/buildSrc/src/main/kotlin/SetupLinter.kt
@@ -1,0 +1,28 @@
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import java.io.File
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+fun Project.setupLinter() {
+    plugins.apply(Dependencies.Plugin.ktlint)
+
+    extensions.findByType(org.jlleitschuh.gradle.ktlint.KtlintExtension::class.java)?.apply {
+        verbose.set(true)
+        android.set(true)
+        ignoreFailures.set(true)
+        coloredOutput.set(true)
+        outputColorName.set("RED")
+        additionalEditorconfigFile.set(File("${rootDir.path}/.editorconfig"))
+        reporters {
+            reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+            reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
+        }
+        filter {
+            include("**/kotlin/**")
+            include("*.kts")
+            exclude("**/generated/**")
+            exclude("**/remote/models/**")
+            exclude("**/remote/apis/**")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/SetupTestCoverage.kt
+++ b/buildSrc/src/main/kotlin/SetupTestCoverage.kt
@@ -1,0 +1,64 @@
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+fun Project.setupTestCoverage() {
+    extensions.findByType(com.android.build.api.dsl.CommonExtension::class.java)?.apply {
+        testOptions {
+            unitTests.all {
+                it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
+                    isDisabled = it.name != "testDevDebugUnitTest"
+                }
+            }
+        }
+    }
+
+//    extensions.findByType(LibraryExtension::class.java)?.apply {
+//        testOptions {
+//            unitTests.all {
+//                it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
+//                    isDisabled = it.name != "testDevDebugUnitTest"
+//                }
+//            }
+//        }
+//    }
+}
+
+fun Project.setupTestCoverageTask() {
+    tasks.withType(kotlinx.kover.tasks.KoverMergedTask::class.java) {
+        excludes = listOf(
+            // Build
+            "*.BuildConfig",
+            "dagger*",
+            "hilt*",
+            "*.*Hilt_*",
+            "*.*_Hilt*",
+            "*.test.*",
+            "*.*Module_*Factory*",
+            "*.*_Factory*",
+            "*.*_MembersInjector*",
+            "*.*_ComponentTreeDeps*",
+            "*.databinding.*",
+            // Modules
+            "*.di.*",
+            "*.domain.core.*",
+            "*.domain.entities.*",
+            "*.domain.repositories.*",
+            "*.data.models.*",
+            "*.data.sources.*",
+            "*.remote.core.*",
+            "*.remote.models.*",
+            "*.remote.apis.*",
+            "*.local.core.*",
+            "*.local.models.*",
+            "*.local.dao.*",
+            "*.presentation.*", // TODO: Add Presentation Test Core
+            "*.presentation.core.*",
+            "*.presentation.statemachine.*",
+            "*.presentation.feature.*.contract.*",
+            "*.ui.*", // TODO: Add Ui Tests
+            "*.ui.primitives.*"
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/SetupTestCoverage.kt
+++ b/buildSrc/src/main/kotlin/SetupTestCoverage.kt
@@ -13,16 +13,6 @@ fun Project.setupTestCoverage() {
             }
         }
     }
-
-//    extensions.findByType(LibraryExtension::class.java)?.apply {
-//        testOptions {
-//            unitTests.all {
-//                it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
-//                    isDisabled = it.name != "testDevDebugUnitTest"
-//                }
-//            }
-//        }
-//    }
 }
 
 fun Project.setupTestCoverageTask() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 23 19:11:29 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# 概要
・gradleのバージョンを上げた
・LinterとTestCoverageをbuildSrcに入れた
・buildSrc/build.gradle.ktsの不要なものを削除した

# 変更種類
- [ ] フィーチャー実装
- [ ] バッグ修正
- [ ] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [ ] Unit Test
- [ ] UI Test
- [ ] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
