### PR TITLE
【バグ修正】リポジトリ詳細のエラーハンドリング

### DIFF
--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/RepositoryDetails.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/entities/RepositoryDetails.kt
@@ -6,9 +6,9 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class RepositoryDetails(
     val repository: Repository,
-    val releases: List<Release>,
-    val contributors: List<User>,
-    val pullRequests: List<PullRequest>
+    val releases: List<Release>?,
+    val contributors: List<User>?,
+    val pullRequests: List<PullRequest>?
 ) : Parcelable {
 
     enum class Element {

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/GetRepositoryDetailsUseCase.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/GetRepositoryDetailsUseCase.kt
@@ -21,9 +21,21 @@ class GetRepositoryDetailsExecutor(
 ) : GetRepositoryDetailsUseCase {
     override suspend fun execute(arguments: GetRepositoryDetailsUseCase.Args): DomainResult<RepositoryDetails> = runHandling(errorHandler) {
         val (contributors, releases, pullRequests) = coroutineScope {
-            val contributors = async { repositoriesRepository.getContributors(name = arguments.repo.name) }
-            val releases = async { repositoriesRepository.getReleases(name = arguments.repo.name) }
-            val pullRequests = async { repositoriesRepository.getPulls(name = arguments.repo.name) }
+            val contributors = async {
+                runCatching {
+                    repositoriesRepository.getContributors(name = arguments.repo.name)
+                }.getOrNull()
+            }
+            val releases = async {
+                runCatching {
+                    repositoriesRepository.getReleases(name = arguments.repo.name)
+                }.getOrNull()
+            }
+            val pullRequests = async {
+                runCatching {
+                    repositoriesRepository.getPulls(name = arguments.repo.name)
+                }.getOrNull()
+            }
             Triple(contributors.await(), releases.await(), pullRequests.await())
         }
         RepositoryDetails(repository = arguments.repo, releases = releases, contributors = contributors, pullRequests = pullRequests)

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/GetRepositoryDetailsUseCase.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/usecases/GetRepositoryDetailsUseCase.kt
@@ -4,11 +4,10 @@ import jp.co.yumemi.android.code_check.domain.core.DomainResult
 import jp.co.yumemi.android.code_check.domain.core.ErrorHandler
 import jp.co.yumemi.android.code_check.domain.core.UseCase
 import jp.co.yumemi.android.code_check.domain.core.runHandling
-import jp.co.yumemi.android.code_check.domain.core.toDomainResult
 import jp.co.yumemi.android.code_check.domain.entities.Repository
 import jp.co.yumemi.android.code_check.domain.entities.RepositoryDetails
 import jp.co.yumemi.android.code_check.domain.repositories.RepositoriesRepository
-import kotlinx.coroutines.async
+import jp.co.yumemi.android.code_check.domain.utils.asyncGetOrNull
 import kotlinx.coroutines.coroutineScope
 
 interface GetRepositoryDetailsUseCase : UseCase<GetRepositoryDetailsUseCase.Args, DomainResult<RepositoryDetails>> {
@@ -21,21 +20,9 @@ class GetRepositoryDetailsExecutor(
 ) : GetRepositoryDetailsUseCase {
     override suspend fun execute(arguments: GetRepositoryDetailsUseCase.Args): DomainResult<RepositoryDetails> = runHandling(errorHandler) {
         val (contributors, releases, pullRequests) = coroutineScope {
-            val contributors = async {
-                runCatching {
-                    repositoriesRepository.getContributors(name = arguments.repo.name)
-                }.getOrNull()
-            }
-            val releases = async {
-                runCatching {
-                    repositoriesRepository.getReleases(name = arguments.repo.name)
-                }.getOrNull()
-            }
-            val pullRequests = async {
-                runCatching {
-                    repositoriesRepository.getPulls(name = arguments.repo.name)
-                }.getOrNull()
-            }
+            val contributors = asyncGetOrNull { repositoriesRepository.getContributors(name = arguments.repo.name) }
+            val releases = asyncGetOrNull { repositoriesRepository.getReleases(name = arguments.repo.name) }
+            val pullRequests = asyncGetOrNull { repositoriesRepository.getPulls(name = arguments.repo.name) }
             Triple(contributors.await(), releases.await(), pullRequests.await())
         }
         RepositoryDetails(repository = arguments.repo, releases = releases, contributors = contributors, pullRequests = pullRequests)

--- a/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/utils/CoroutineExt.kt
+++ b/domain/src/main/kotlin/jp/co/yumemi/android/code_check/domain/utils/CoroutineExt.kt
@@ -1,0 +1,18 @@
+package jp.co.yumemi.android.code_check.domain.utils
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+fun <T> CoroutineScope.asyncGetOrNull(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> T
+): Deferred<T?> = async(context, start) {
+    runCatching {
+        block()
+    }.getOrNull()
+}

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/components/repo/RepositoryDetailsElementItem.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/components/repo/RepositoryDetailsElementItem.kt
@@ -21,14 +21,19 @@ fun RepositoryDetailsElementItem(
     repoDetails: RepositoryDetails,
     element: RepositoryDetails.Element,
     modifier: Modifier = Modifier
-) = CommonListItem(
-    icon = element.icon(),
-    title = stringResource(id = element.label()),
-    iconColor = Github.White,
-    iconBackground = element.iconBackground,
-    note = element.note(repoDetails),
-    modifier = modifier
-)
+) {
+    val note = element.note(repoDetails)
+    if (note != null) {
+        CommonListItem(
+            icon = element.icon(),
+            title = stringResource(id = element.label()),
+            iconColor = Github.White,
+            iconBackground = element.iconBackground,
+            note = note,
+            modifier = modifier
+        )
+    }
+}
 
 @Preview
 @Composable

--- a/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/RepositoryDetailsElementExt.kt
+++ b/ui/src/main/kotlin/jp/co/yumemi/android/code_check/ui/utils/RepositoryDetailsElementExt.kt
@@ -45,9 +45,9 @@ val RepositoryDetails.Element.iconBackground
 @Composable
 fun RepositoryDetails.Element.note(details: RepositoryDetails) = when (this) {
     RepositoryDetails.Element.Issues -> details.repository.openIssuesCount.toShortedString()
-    RepositoryDetails.Element.PullRequests -> details.pullRequests.size.toShortedString()
-    RepositoryDetails.Element.Releases -> details.releases.size.toDoubleDigitString()
-    RepositoryDetails.Element.Contributors -> details.contributors.size.toDoubleDigitString()
+    RepositoryDetails.Element.PullRequests -> details.pullRequests?.size?.toShortedString()
+    RepositoryDetails.Element.Releases -> details.releases?.size?.toDoubleDigitString()
+    RepositoryDetails.Element.Contributors -> details.contributors?.size?.toDoubleDigitString()
     RepositoryDetails.Element.Watchers -> details.repository.watchersCount.toShortedString()
     RepositoryDetails.Element.License -> details.repository.license
 }


### PR DESCRIPTION
# 概要
・RepositoryDetailsのreleases, contributors, pull requestsをnullableにした
・APIを叩くときに、取れないものをnullにした

# 変更種類
- [ ] フィーチャー実装
- [x] バッグ修正
- [ ] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [ ] Unit Test
- [ ] UI Test
- [x] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
