### PR TITLE
【テスト】最近検索：Local

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     // KotlinX
     implementation(Dependencies.Kotlinx.coroutinesAndroid)
+    implementation(Dependencies.Kotlinx.datetime)
 
     // Ktor
     implementation(Dependencies.Ktor.clientAndroid)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/AppModule.kt
@@ -8,10 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.co.yumemi.android.code_check.data.error.DefaultErrorHandler
+import jp.co.yumemi.android.code_check.data.utils.InstantProvider
 import jp.co.yumemi.android.code_check.domain.core.ErrorHandler
 import jp.co.yumemi.android.code_check.local.core.AppDatabase
 import jp.co.yumemi.android.code_check.remote.core.DefaultHttpClientProvider
 import jp.co.yumemi.android.code_check.remote.core.HttpClientProvider
+import kotlinx.datetime.Clock
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -26,4 +28,7 @@ class AppModule {
 
     @Provides
     fun provideHttpClientProvider(): HttpClientProvider = DefaultHttpClientProvider()
+
+    @Provides
+    fun provideInstantProvider(): InstantProvider = InstantProvider { Clock.System.now() }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/LocalModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/LocalModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 import javax.inject.Qualifier
 import jp.co.yumemi.android.code_check.data.error.ExceptionHandler
 import jp.co.yumemi.android.code_check.data.sources.SearchLocalDataSource
+import jp.co.yumemi.android.code_check.data.utils.InstantProvider
 import jp.co.yumemi.android.code_check.local.core.AppDatabase
 import jp.co.yumemi.android.code_check.local.providers.SearchLocalDataProvider
 import jp.co.yumemi.android.code_check.remote.error.RemoteExceptionHandler
@@ -21,8 +22,9 @@ class LocalModule {
     @Provides
     fun provideLocalDataSource(
         database: AppDatabase,
+        instantProvider: InstantProvider,
         @Local exceptionHandler: ExceptionHandler,
-    ): SearchLocalDataSource = SearchLocalDataProvider(database.searchDao(), exceptionHandler)
+    ): SearchLocalDataSource = SearchLocalDataProvider(database.searchDao(), instantProvider, exceptionHandler)
 }
 
 @Qualifier

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     projectTest(Modules.Test)
 
     implementation(Dependencies.Kotlinx.serializationJson)
+    implementation(Dependencies.Kotlinx.datetime)
 }

--- a/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/utils/InstantProvider.kt
+++ b/data/src/main/kotlin/jp/co/yumemi/android/code_check/data/utils/InstantProvider.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.android.code_check.data.utils
+
+import kotlinx.datetime.Instant
+
+fun interface InstantProvider {
+    fun now(): Instant
+}

--- a/local/src/main/kotlin/jp/co/yumemi/android/code_check/local/providers/SearchLocalDataProvider.kt
+++ b/local/src/main/kotlin/jp/co/yumemi/android/code_check/local/providers/SearchLocalDataProvider.kt
@@ -4,6 +4,7 @@ import jp.co.yumemi.android.code_check.data.error.ExceptionHandler
 import jp.co.yumemi.android.code_check.data.error.runHandling
 import jp.co.yumemi.android.code_check.data.models.RecentSearchModel
 import jp.co.yumemi.android.code_check.data.sources.SearchLocalDataSource
+import jp.co.yumemi.android.code_check.data.utils.InstantProvider
 import jp.co.yumemi.android.code_check.local.dao.SearchDao
 import jp.co.yumemi.android.code_check.local.mappers.RecentSearchLocalMapper
 import jp.co.yumemi.android.code_check.local.models.RecentSearchDbModel
@@ -11,13 +12,14 @@ import kotlinx.datetime.Clock
 
 class SearchLocalDataProvider(
     private val searchDao: SearchDao,
+    private val instantProvider: InstantProvider,
     private val exceptionHandler: ExceptionHandler,
 ) : SearchLocalDataSource {
     override suspend fun saveRecentSearch(searchText: String) = runHandling(exceptionHandler) {
         searchDao.insertAll(
             RecentSearchDbModel(
                 searchText = searchText,
-                timestamp = Clock.System.now().epochSeconds
+                timestamp = instantProvider.now().epochSeconds
             )
         )
     }

--- a/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/error/LocalExceptionHandlerTest.kt
+++ b/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/error/LocalExceptionHandlerTest.kt
@@ -1,0 +1,17 @@
+package jp.co.yumemi.android.code_check.local.error
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import jp.co.yumemi.android.code_check.data.error.DataException
+import org.junit.Test
+
+class LocalExceptionHandlerTest {
+    private val localExceptionHandler = LocalExceptionHandler()
+    private val textException = Exception("test")
+
+    @Test
+    fun `test local exception handler`() {
+        val exception = localExceptionHandler.handle(textException)
+        exception shouldBe DataException.LocalException.DatabaseException(message = textException.message, cause = textException)
+    }
+}

--- a/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/error/LocalExceptionHandlerTest.kt
+++ b/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/error/LocalExceptionHandlerTest.kt
@@ -1,7 +1,6 @@
 package jp.co.yumemi.android.code_check.local.error
 
 import io.kotest.matchers.shouldBe
-import io.mockk.coVerify
 import jp.co.yumemi.android.code_check.data.error.DataException
 import org.junit.Test
 

--- a/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/models/DefaultModel.kt
+++ b/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/models/DefaultModel.kt
@@ -1,0 +1,5 @@
+package jp.co.yumemi.android.code_check.local.models
+
+object DefaultModel {
+    val recentSearch = RecentSearchDbModel(searchText = "", timestamp = 0)
+}

--- a/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/providers/SearchLocalDataProviderTest.kt
+++ b/local/src/test/kotlin/jp/co/yumemi/android/code_check/local/providers/SearchLocalDataProviderTest.kt
@@ -1,15 +1,21 @@
 package jp.co.yumemi.android.code_check.local.providers
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import jp.co.yumemi.android.code_check.data.error.DataException
 import jp.co.yumemi.android.code_check.data.error.ExceptionHandler
+import jp.co.yumemi.android.code_check.data.utils.InstantProvider
 import jp.co.yumemi.android.code_check.local.dao.SearchDao
 import jp.co.yumemi.android.code_check.local.models.RecentSearchDbModel
 import jp.co.yumemi.android.code_check.test.CoroutineTestRule
 import jp.co.yumemi.android.code_check.test.runBlockingTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.datetime.Instant
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,25 +25,47 @@ class SearchLocalDataProviderTest {
     val coroutineTestRule = CoroutineTestRule()
     private val searchDao = mockk<SearchDao>()
     private val exceptionHandler = mockk<ExceptionHandler>()
-    private val searchLocalDataSource = SearchLocalDataProvider(searchDao, exceptionHandler)
-    private val testException = Exception("test")
+    private val instantProvider = mockk<InstantProvider>()
+    private val searchLocalDataSource = SearchLocalDataProvider(searchDao, instantProvider, exceptionHandler)
+    private val listSize = 5
+
+    @Before
+    fun setup() {
+        every { exceptionHandler.handle(throwable = any()) } returns DataException.Unknown()
+        every { instantProvider.now() } returns Instant.fromEpochSeconds(0)
+    }
 
     @Test
     fun `test getting recent searches`() {
         coEvery {
             searchDao.getAll()
-        } returns List(5) { index ->
+        } returns List(listSize) { index ->
             RecentSearchDbModel("$index", index.toLong())
         }
 
         coroutineTestRule.runBlockingTest {
             val result = searchLocalDataSource.getRecentSearches()
-            result.size shouldBe 5
+            result.size shouldBe listSize
             result.forEachIndexed { index, item ->
                 item.searchText shouldBe "$index"
                 item.timestamp shouldBe index.toLong()
             }
             coVerify { searchDao.getAll() }
+            coVerify(inverse = true) { exceptionHandler.handle(throwable = any()) }
+        }
+    }
+
+    @Test
+    fun `test database failure`() {
+        coEvery {
+            searchDao.getAll()
+        } throws Exception()
+
+        coroutineTestRule.runBlockingTest {
+            val result = shouldThrow<DataException> { searchLocalDataSource.getRecentSearches() }
+            result shouldBe DataException.Unknown()
+            coVerify { searchDao.getAll() }
+            coVerify { exceptionHandler.handle(throwable = any()) }
         }
     }
 
@@ -48,8 +76,22 @@ class SearchLocalDataProviderTest {
         } returns Unit
 
         coroutineTestRule.runBlockingTest {
-            searchLocalDataSource.saveRecentSearch("")
-            coVerify { searchDao.insertAll(*anyVararg()) }
+            searchLocalDataSource.saveRecentSearch(searchText = "")
+            coVerify { searchDao.insertAll(*varargAny { it.searchText == "" && it.timestamp == 0L }) }
+            coVerify(inverse = true) { exceptionHandler.handle(throwable = any()) }
+        }
+    }
+
+    @Test
+    fun `test deleting all recent searches`() {
+        coEvery {
+            searchDao.deleteAll()
+        } returns Unit
+
+        coroutineTestRule.runBlockingTest {
+            searchLocalDataSource.deleteAllRecentSearches()
+            coVerify { searchDao.deleteAll() }
+            coVerify(inverse = true) { exceptionHandler.handle(throwable = any()) }
         }
     }
 }


### PR DESCRIPTION
# 概要
・Clock.System.now()をInstantProviderにリファクタした
・テストを追加した

# 変更種類
- [ ] フィーチャー実装
- [ ] バッグ修正
- [ ] リファクタ
- [ ] ドキュメンテーション
- [ ] その他（）

# テスト
- [ ] Unit Test
- [ ] UI Test
- [ ] 動作確認
- [ ] N/A

<!-- UIの実装か変更の場合
# UI
<img width="250" alt="UI" src="">
-->

<!-- UMLの追加か変更の場合
# UML
![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/gmvalentino8/github-sample-project/{BRANCH}/presentation/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/feature/{PATH/NAME}.pu)
-->
